### PR TITLE
Add note about error when running upload.js

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -313,6 +313,10 @@ If we run this it will log out:
   '/Users/jmazz/Documents/repos/igemwiki-api/recipes/simple/js/vendor.js' ]
 ```
 
+If you get a `RequestError`, `SSL routines:ssl_choose_client_version:unsupported protocol`, run your file with 
+the flag: `--tls-min-v1.0` as follows: `node --tls-min-v1.0 upload.js`.
+
+
 **Our goal is to create a mapping between filenames and wiki page
 destinations**. So, let's seperate our types:
 


### PR DESCRIPTION
Hi! I'm working on using this for my team's 2020 wiki. Just thought I would add this here. Here was my full error: 
  ```
name: 'RequestError',
message: 'Error: write EPROTO 140735546028928:error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol:../deps/openssl/openssl/ssl/statem/statem_lib.c:1929:\n',
```